### PR TITLE
Throttle parallax background updates with requestAnimationFrame

### DIFF
--- a/Pedadoc-ui-kit (light+dark).html
+++ b/Pedadoc-ui-kit (light+dark).html
@@ -409,10 +409,17 @@ body.theme-light .btn.secondary{
   });
 
   // Parallax background on mouse move (subtle)
-  document.addEventListener('mousemove', (e)=>{
-    const x = (e.clientX / window.innerWidth - .5) * 4;
-    const y = (e.clientY / window.innerHeight - .5) * 4;
+  let raf = 0;
+  let lastPos = {x: 0, y: 0};
+  function applyParallax(){
+    const x = (lastPos.x / window.innerWidth - .5) * 4;
+    const y = (lastPos.y / window.innerHeight - .5) * 4;
     document.body.style.backgroundPosition = `${50 - x}% ${50 - y}%`;
+    raf = 0;
+  }
+  document.addEventListener('mousemove', (e)=>{
+    lastPos = {x: e.clientX, y: e.clientY};
+    if(!raf){ raf = requestAnimationFrame(applyParallax); }
   }, {passive:true});
 
   // Smooth scroll helper


### PR DESCRIPTION
## Summary
- throttle parallax background style updates using requestAnimationFrame
- compute parallax x/y inside scheduled frame from last mouse position

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68badde1a868832ab842c1fcb01b115f