### PR TITLE
Expand mock authentication with multi-step signup flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,8 +633,7 @@ body.theme-light .btn.secondary{
       const pass = document.getElementById('loginPass').value;
       if(!email || !pass) return showAuthErr('Заполните email и пароль');
       setState({email, name: email.split('@')[0], verified:true, role:'', profile:{}, stage:'done'});
-      toast('Вы вошли');
-      renderAuth();
+      window.location.href = 'dashboard.html';
     };
   }
 
@@ -774,8 +773,7 @@ body.theme-light .btn.secondary{
       const err = validateProfile(role, profile);
       if(err) return showAuthErr(err);
       setState({...s, role, profile, stage:'done'});
-      toast('Профиль сохранён');
-      renderAuth();
+      window.location.href = 'dashboard.html';
     };
 
     function renderRoleFields(r){

--- a/index.html
+++ b/index.html
@@ -245,6 +245,87 @@ body.theme-light .btn.secondary{
   color:#1C1C1E;
 }
 
+/* Auth card */
+.auth-card{
+  background:#111417; border:1px solid #1f2329; border-radius:16px;
+  padding:16px; max-width:420px; margin-left:auto; box-shadow:0 12px 32px -16px #000a;
+}
+.theme-light .auth-card{ background:#fff; border:1px solid #E6E8EB; box-shadow:0 10px 24px -18px rgba(0,0,0,.15); }
+
+.auth-tabs{display:flex; gap:8px; margin-bottom:12px}
+.auth-tab{
+  flex:1; text-align:center; padding:10px 12px; border-radius:10px; cursor:pointer; font-weight:800;
+  background:#1a1e24; color:#EDEFF2; border:1px solid #242932;
+}
+.auth-tab.active{ background:linear-gradient(135deg,var(--accent),var(--accent-2)); color:#1C1303; border-color:transparent; }
+.theme-light .auth-tab{ background:#F4F5F7; color:#1C1C1E; border-color:#E6E8EB }
+.theme-light .auth-tab.active{ color:#1C1303 }
+
+.auth-field{display:flex; align-items:center; margin-bottom:10px; background:#0f1317; border:1px solid #1e232a; border-radius:10px; padding:8px 10px}
+.auth-field input{flex:1; background:transparent; border:none; color:var(--ink); outline:none; font-size:14px}
+.auth-eye{cursor:pointer; opacity:.7}
+.theme-light .auth-field{ background:#FFFFFF; border-color:#E6E8EB }
+
+.auth-actions{display:flex; align-items:center; justify-content:space-between; gap:8px; margin-top:8px}
+.auth-actions .link{font-size:12px; color:var(--ink-dim); text-decoration:underline; cursor:pointer}
+
+.auth-btn{width:100%; padding:12px 14px; border:none; border-radius:12px; font-weight:900; cursor:pointer;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2)); color:#1C1303;
+  box-shadow: 0 12px 26px -14px rgba(255,176,32,.35);
+}
+
+.auth-consents{margin-top:8px; font-size:12px; color:var(--ink-dim)}
+.auth-consents label{display:flex; gap:8px; align-items:flex-start; margin-top:6px}
+.auth-consents a{color:var(--ink-dim); text-decoration:underline}
+
+.auth-error{margin-top:8px; color:#ff9aa2; font-size:12px}
+
+/* Avatar in header */
+.user-chip{display:flex; align-items:center; gap:10px; margin-right:8px}
+.user-ava{width:28px; height:28px; border-radius:50%; background:linear-gradient(135deg,#2F343C,#1F2937); color:#fff; display:grid; place-items:center; font-size:12px; font-weight:800}
+.user-name{font-weight:700; color:var(--ink)}
+.user-menu{position:relative}
+.user-dd{position:absolute; right:0; top:36px; background:#12161b; border:1px solid #1f2329; border-radius:12px; padding:8px; display:none; min-width:160px; z-index:40}
+.user-dd a{display:block; padding:8px 10px; border-radius:8px; color:var(--ink); text-decoration:none}
+.user-dd a:hover{background:#ffffff10}
+.theme-light .user-dd{ background:#fff; border-color:#E6E8EB }
+
+/* === Multi-step UI === */
+.stepper{display:flex; gap:8px; align-items:center; margin-bottom:12px}
+.step-dot{width:8px; height:8px; border-radius:50%; background:#2a2f36; opacity:.6}
+.step-dot.active{background:linear-gradient(135deg,var(--accent),var(--accent-2)); opacity:1}
+.theme-light .step-dot{ background:#E6E8EB }
+
+/* OTP (код из 6 цифр) */
+.otp{display:flex; gap:8px; justify-content:space-between; margin:10px 0 12px}
+.otp input{
+  width:44px; height:52px; text-align:center; font-size:22px; font-weight:800; border-radius:12px;
+  background:#0f1317; border:1px solid #1e232a; color:var(--ink); outline:none;
+}
+.theme-light .otp input{ background:#fff; border-color:#E6E8EB }
+.otp input:focus{ box-shadow:0 0 0 2px #ffffff22 inset }
+
+/* Roles selector */
+.roles{display:flex; gap:8px; margin:8px 0 14px}
+.role-chip{
+  padding:10px 12px; border-radius:12px; cursor:pointer; font-weight:800; border:1px solid #242932;
+  background:#14181e; color:#EDEFF2;
+}
+.role-chip.active{ background:linear-gradient(135deg,var(--accent),var(--accent-2)); color:#1C1303; border-color:transparent}
+.theme-light .role-chip{ background:#F4F5F7; color:#1C1C1E; border-color:#E6E8EB }
+
+/* Profile form */
+.profile-grid{display:grid; grid-template-columns:1fr 1fr; gap:10px}
+@media (max-width:640px){ .profile-grid{grid-template-columns:1fr} }
+.profile-field{
+  display:flex; flex-direction:column; gap:6px; background:#0f1317; border:1px solid #1e232a; border-radius:10px; padding:10px
+}
+.profile-field input, .profile-field select{
+  background:transparent; border:none; color:var(--ink); outline:none; font-size:14px
+}
+.theme-light .profile-field{ background:#fff; border-color:#E6E8EB }
+.profile-actions{display:flex; gap:8px; margin-top:10px}
+
 </style>
 
 </head>
@@ -255,6 +336,7 @@ body.theme-light .btn.secondary{
         <span class="logo-mark" aria-hidden="true"></span>
         <span>PedaDoc</span>
       </a>
+      <div id="userSlot"></div>
       <nav class="nav" aria-label="Главная навигация">
         <a href="#cases">Кейсы</a>
         <a href="#sims">Тренажёры</a>
@@ -288,15 +370,7 @@ body.theme-light .btn.secondary{
             <div class="note" style="transform:rotate(.5deg)">Формирующее оценивание</div>
           </div>
         </div>
-        <!-- Chalkboard doodles / demo simulator preview -->
-        <div aria-hidden="true" style="position:relative; min-height:280px">
-          <canvas id="chalk" width="520" height="280" style="width:100%;height:auto;border-radius:14px;box-shadow:inset 0 0 0 1px #ffffff14"></canvas>
-          <div class="chalk-doodle big" style="top:10px; left:12px;">↳ Вы — педагог</div>
-          <div class="chalk-doodle small" style="bottom:16px; left:8px; animation-delay: .9s">“Как вы отреагируете?”</div>
-          <div class="chalk-doodle small" style="top:16px; right:8px; transform:rotate(6deg); animation-delay: .3s">★ эмпатия</div>
-          <div class="chalk-doodle small" style="bottom:8px; right:14px; transform:rotate(-8deg); animation-delay: 1.2s">✓ структура урока</div>
-          <span class="chalk-line" style="left:0; right:0; top:52%;"></span>
-        </div>
+        <div id="heroRight" style="position:relative; min-height:320px"></div>
       </div>
     </div>
   </section>
@@ -441,31 +515,331 @@ body.theme-light .btn.secondary{
   }
   window.toast = toast;
 
-  // Chalk canvas: draw faint “chalk” as user moves mouse
-  const canvas = document.getElementById('chalk');
-  const ctx = canvas.getContext('2d');
-  let last = null;
-  function dot(x,y){
-    ctx.fillStyle = 'rgba(255,255,255,.7)';
-    for(let i=0;i<6;i++){
-      const ox = (Math.random()-.5)*3;
-      const oy = (Math.random()-.5)*3;
-      ctx.fillRect(x+ox, y+oy, 1, 1);
+  // ===== AUTH STATE (demo via localStorage) =====
+  // Состояние храним в localStorage. Структура:
+  // { email, name, verified, role, profile:{...}, stage?: 'verify'|'profile'|'done' }
+  const AUTH_KEY = 'pedadoc-auth';
+
+  function getState(){
+    try{ return JSON.parse(localStorage.getItem(AUTH_KEY)) || null; }catch{ return null; }
+  }
+  function setState(obj){
+    localStorage.setItem(AUTH_KEY, JSON.stringify(obj));
+  }
+  function clearState(){ localStorage.removeItem(AUTH_KEY); }
+  function isSignedIn(){
+    const s = getState();
+    return !!(s && s.email && (!s.stage || s.stage==='done'));
+  }
+  function initials(name){ return (name||'').split(/\s+/).map(w=>w[0]).slice(0,2).join('').toUpperCase() || 'U'; }
+
+  // ===== HEADER USER CHIP =====
+  function renderHeaderUser(){
+    const slot = document.getElementById('userSlot');
+    if(!slot) return;
+    const s = getState();
+    if(!isSignedIn()){ slot.innerHTML=''; return; }
+    slot.innerHTML = `
+      <div class="user-menu">
+        <div class="user-chip" id="userChip" tabindex="0" role="button" aria-haspopup="true">
+          <div class="user-ava">${initials(s.name||s.email)}</div>
+          <div class="user-name">${s.name || s.email}</div>
+        </div>
+        <div class="user-dd" id="userDd">
+          <a href="#track">Мой маршрут</a>
+          <a href="#cases">Мои кейсы</a>
+          <a href="#" id="logoutLink">Выйти</a>
+        </div>
+      </div>`;
+    const chip = slot.querySelector('#userChip');
+    const dd = slot.querySelector('#userDd');
+    const logout = slot.querySelector('#logoutLink');
+    chip.addEventListener('click', ()=> dd.style.display = dd.style.display==='block' ? 'none':'block');
+    document.addEventListener('click', (e)=>{ if(!slot.contains(e.target)) dd.style.display='none'; });
+    logout.addEventListener('click', (e)=>{ e.preventDefault(); clearState(); renderAuth(); toast('Вы вышли'); });
+  }
+
+  // ===== HERO RIGHT: auth flow (login/reg -> verify -> profile) OR chalk =====
+  function renderHeroRight(){
+    const host = document.getElementById('heroRight');
+    if(!host) return;
+    const s = getState();
+
+    // Кнопка «Старт практики»
+    const startBtn = document.getElementById('startBtn');
+    if(startBtn){
+      if(isSignedIn()){ startBtn.textContent='Продолжить маршрут'; startBtn.onclick=()=>scrollToId('track'); }
+      else if(s && s.stage){ startBtn.textContent='Продолжить регистрацию'; startBtn.onclick=()=>{}; }
+      else { startBtn.textContent='Старт практики'; startBtn.onclick=()=>scrollToId('cases'); }
+    }
+
+    if(isSignedIn()){
+      host.innerHTML = `
+        <canvas id="chalk" width="520" height="280" style="width:100%;height:auto;border-radius:14px;box-shadow:inset 0 0 0 1px #ffffff14"></canvas>
+        <div class="chalk-doodle big" style="top:10px; left:12px;">↳ Вы — педагог</div>
+        <div class="chalk-doodle small" style="bottom:16px; left:8px; animation-delay: .9s">“Как вы отреагируете?”</div>
+        <div class="chalk-doodle small" style="top:16px; right:8px; transform:rotate(6deg); animation-delay: .3s">★ эмпатия</div>
+        <div class="chalk-doodle small" style="bottom:8px; right:14px; transform:rotate(-8deg); animation-delay: 1.2s">✓ структура урока</div>
+        <span class="chalk-line" style="left:0; right:0; top:52%;"></span>
+      `;
+      initChalk();
+      return;
+    }
+
+    if(s && s.stage === 'verify'){ mountVerify(); return; }
+    if(s && s.stage === 'profile'){ mountProfile(); return; }
+
+    host.innerHTML = `
+      <div class="auth-card" role="group" aria-label="Вход и регистрация">
+        <div class="stepper" aria-hidden="true">
+          <span class="step-dot active"></span><span class="step-dot"></span><span class="step-dot"></span>
+        </div>
+        <div class="auth-tabs">
+          <button class="auth-tab active" id="tabLogin">Вход</button>
+          <button class="auth-tab" id="tabReg">Регистрация</button>
+        </div>
+        <div id="authBody"></div>
+      </div>`;
+    mountLogin();
+  }
+
+  function wireTabs(){
+    const tLogin = document.getElementById('tabLogin');
+    const tReg = document.getElementById('tabReg');
+    if(!tLogin || !tReg) return;
+    tLogin.onclick = ()=>{ tLogin.classList.add('active'); tReg.classList.remove('active'); mountLogin(); };
+    tReg.onclick = ()=>{ tReg.classList.add('active'); tLogin.classList.remove('active'); mountReg(); };
+  }
+
+  /* ---------- ВХОД ---------- */
+  function mountLogin(){
+    const body = document.getElementById('authBody');
+    if(!body) return;
+    body.innerHTML = `
+      <div class="auth-field"><input id="loginEmail" type="email" placeholder="Email" autocomplete="email"></div>
+      <div class="auth-field">
+        <input id="loginPass" type="password" placeholder="Пароль" autocomplete="current-password">
+        <span class="auth-eye" id="eyeLogin">👁</span>
+      </div>
+      <div class="auth-actions">
+        <span class="link" id="forgotLink">Забыли пароль?</span>
+      </div>
+      <button class="auth-btn" id="loginBtn">Войти</button>
+      <div class="auth-error" id="authErr" style="display:none"></div>
+    `;
+    document.getElementById('eyeLogin').onclick = ()=>toggleEye('loginPass');
+    document.getElementById('forgotLink').onclick = ()=>{ toast('Ссылка на сброс отправлена на email'); };
+    document.getElementById('loginBtn').onclick = ()=>{
+      const email = document.getElementById('loginEmail').value.trim();
+      const pass = document.getElementById('loginPass').value;
+      if(!email || !pass) return showAuthErr('Заполните email и пароль');
+      setState({email, name: email.split('@')[0], verified:true, role:'', profile:{}, stage:'done'});
+      toast('Вы вошли');
+      renderAuth();
+    };
+  }
+
+  /* ---------- РЕГИСТРАЦИЯ (шаг 1/3) ---------- */
+  function mountReg(){
+    const body = document.getElementById('authBody');
+    if(!body) return;
+    body.innerHTML = `
+      <div class="auth-field"><input id="regName" type="text" placeholder="Имя и фамилия" autocomplete="name"></div>
+      <div class="auth-field"><input id="regEmail" type="email" placeholder="Email" autocomplete="email"></div>
+      <div class="auth-field">
+        <input id="regPass" type="password" placeholder="Пароль" autocomplete="new-password">
+        <span class="auth-eye" id="eye1">👁</span>
+      </div>
+      <div class="auth-field">
+        <input id="regPass2" type="password" placeholder="Повтор пароля" autocomplete="new-password">
+        <span class="auth-eye" id="eye2">👁</span>
+      </div>
+      <div class="auth-consents">
+        <label><input type="checkbox" id="c1"> Согласен(а) на обработку персональных данных</label>
+        <label><input type="checkbox" id="c2"> Принимаю <a href="#" target="_blank">Пользовательское соглашение</a> и <a href="#" target="_blank">Политику конфиденциальности</a></label>
+      </div>
+      <button class="auth-btn" id="regBtn" style="margin-top:10px">Зарегистрироваться</button>
+      <div class="auth-error" id="authErr" style="display:none"></div>
+    `;
+    document.getElementById('eye1').onclick = ()=>toggleEye('regPass');
+    document.getElementById('eye2').onclick = ()=>toggleEye('regPass2');
+    document.getElementById('regBtn').onclick = ()=>{
+      const name = document.getElementById('regName').value.trim();
+      const email = document.getElementById('regEmail').value.trim();
+      const p1 = document.getElementById('regPass').value;
+      const p2 = document.getElementById('regPass2').value;
+      const c1 = document.getElementById('c1').checked;
+      const c2 = document.getElementById('c2').checked;
+      if(!name || !email || !p1 || !p2) return showAuthErr('Заполните все поля');
+      if(p1 !== p2) return showAuthErr('Пароли не совпадают');
+      if(!c1 || !c2) return showAuthErr('Подтвердите согласия');
+      setState({email, name, verified:false, role:'', profile:{}, stage:'verify'});
+      mountVerify();
+    };
+  }
+
+  /* ---------- ПОДТВЕРЖДЕНИЕ КОДОМ (шаг 2/3) ---------- */
+  function mountVerify(){
+    const host = document.getElementById('heroRight');
+    const s = getState();
+    if(!host || !s) return;
+    host.innerHTML = `
+      <div class="auth-card">
+        <div class="stepper"><span class="step-dot active"></span><span class="step-dot active"></span><span class="step-dot"></span></div>
+        <div style="font-weight:800; margin-bottom:6px">Подтвердите почту</div>
+        <div style="color:var(--ink-dim); font-size:14px; margin-bottom:6px">Мы отправили код на <strong>${s.email}</strong></div>
+        <div class="otp" id="otpBox">
+          <input inputmode="numeric" maxlength="1">
+          <input inputmode="numeric" maxlength="1">
+          <input inputmode="numeric" maxlength="1">
+          <input inputmode="numeric" maxlength="1">
+          <input inputmode="numeric" maxlength="1">
+          <input inputmode="numeric" maxlength="1">
+        </div>
+        <div class="auth-actions">
+          <span class="link" id="resendCode">Отправить код повторно</span>
+          <span class="link" id="changeEmail">Изменить email</span>
+        </div>
+        <button class="auth-btn" id="verifyBtn">Подтвердить</button>
+        <div class="auth-error" id="authErr" style="display:none"></div>
+      </div>
+    `;
+    initOtp(document.querySelectorAll('#otpBox input'));
+    document.getElementById('resendCode').onclick = ()=> toast('Код отправлен повторно');
+    document.getElementById('changeEmail').onclick = ()=>{ renderHeroRight(); document.getElementById('tabReg').click(); };
+    document.getElementById('verifyBtn').onclick = ()=>{
+      const code = [...document.querySelectorAll('#otpBox input')].map(i=>i.value).join('');
+      if(code.length!==6) return showAuthErr('Введите 6 цифр');
+      setState({...s, verified:true, stage:'profile'});
+      mountProfile();
+    };
+  }
+
+  function initOtp(inputs){
+    inputs[0].focus();
+    inputs.forEach((inp,idx)=>{
+      inp.addEventListener('input', e=>{
+        inp.value = (inp.value||'').replace(/\D/g,'').slice(0,1);
+        if(inp.value && idx<inputs.length-1) inputs[idx+1].focus();
+      });
+      inp.addEventListener('keydown', e=>{
+        if(e.key==='Backspace' && !inp.value && idx>0){ inputs[idx-1].focus(); }
+      });
+      inp.addEventListener('paste', e=>{
+        const txt = (e.clipboardData.getData('text')||'').replace(/\D/g,'').slice(0,6);
+        if(!txt) return;
+        e.preventDefault();
+        [...txt].forEach((d,i)=>{ if(inputs[i]) inputs[i].value = d; });
+        const last = Math.min(txt.length, inputs.length)-1; inputs[last].focus();
+      });
+    });
+  }
+
+  /* ---------- АНКЕТА (шаг 3/3) ---------- */
+  function mountProfile(){
+    const host = document.getElementById('heroRight');
+    const s = getState();
+    if(!host || !s) return;
+    host.innerHTML = `
+      <div class="auth-card">
+        <div class="stepper"><span class="step-dot active"></span><span class="step-dot active"></span><span class="step-dot active"></span></div>
+        <div style="font-weight:800; margin-bottom:6px">Расскажите о себе</div>
+        <div style="color:var(--ink-dim); font-size:14px; margin-bottom:8px">Выберите роль и заполните поля — подстроим тренажёры и кейсы.</div>
+
+        <div class="roles">
+          <button class="role-chip" data-role="student">Студент</button>
+          <button class="role-chip" data-role="teacher">Учитель</button>
+          <button class="role-chip" data-role="slp">Дефектолог/Логопед</button>
+        </div>
+
+        <div id="profileFields"></div>
+
+        <div class="profile-actions">
+          <button class="auth-btn" id="saveProfile">Сохранить профиль</button>
+        </div>
+        <div class="auth-error" id="authErr" style="display:none"></div>
+      </div>
+    `;
+
+    const chips = [...host.querySelectorAll('.role-chip')];
+    let role = s.role || 'student';
+    function mark(){
+      chips.forEach(c=>c.classList.toggle('active', c.dataset.role===role));
+      renderRoleFields(role);
+    }
+    chips.forEach(c=> c.onclick = ()=>{ role = c.dataset.role; mark(); });
+    mark();
+
+    document.getElementById('saveProfile').onclick = ()=>{
+      const profile = readProfile(role);
+      const err = validateProfile(role, profile);
+      if(err) return showAuthErr(err);
+      setState({...s, role, profile, stage:'done'});
+      toast('Профиль сохранён');
+      renderAuth();
+    };
+
+    function renderRoleFields(r){
+      const box = document.getElementById('profileFields');
+      if(r==='student'){
+        box.innerHTML = `
+          <div class="profile-grid">
+            <label class="profile-field"><span>ВУЗ</span><input id="p_university" placeholder="Например, МПГУ"></label>
+            <label class="profile-field"><span>Направление</span><input id="p_major" placeholder="Педагогическое образование ..."></label>
+            <label class="profile-field"><span>Курс</span><select id="p_course"><option value="">Выберите курс</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></label>
+            <label class="profile-field"><span>Предмет</span><input id="p_subject" placeholder="Математика / Русский / ..."></label>
+          </div>`;
+      }else if(r==='teacher'){
+        box.innerHTML = `
+          <div class="profile-grid">
+            <label class="profile-field"><span>Город</span><input id="p_city" placeholder="Например, Казань"></label>
+            <label class="profile-field"><span>Школа</span><input id="p_school" placeholder="Школа №..."></label>
+            <label class="profile-field"><span>Предмет</span><input id="p_subject" placeholder="Математика / Русский / ..."></label>
+            <label class="profile-field"><span>Стаж</span><select id="p_exp"><option value="">Стаж</option><option>0–1</option><option>2–3</option><option>4–7</option><option>8–15</option><option>15+</option></select></label>
+          </div>`;
+      }else{
+        box.innerHTML = `
+          <div class="profile-grid">
+            <label class="profile-field"><span>Город</span><input id="p_city" placeholder="Например, Самара"></label>
+            <label class="profile-field"><span>Специализация</span><select id="p_spec"><option value="">Выберите</option><option>Логопед</option><option>Дефектолог</option><option>Тифлопедагог</option><option>Сурдопедагог</option></select></label>
+            <label class="profile-field"><span>Опыт</span><select id="p_exp"><option value="">Стаж</option><option>0–1</option><option>2–3</option><option>4–7</option><option>8–15</option><option>15+</option></select></label>
+            <label class="profile-field"><span>Предмет/направление</span><input id="p_subject" placeholder="Напр., коррекционная педагогика"></label>
+          </div>`;
+      }
+    }
+
+    function readProfile(r){
+      const v = id=> (document.getElementById(id)?.value || '').trim();
+      if(r==='student') return { university:v('p_university'), major:v('p_major'), course:v('p_course'), subject:v('p_subject') };
+      if(r==='teacher') return { city:v('p_city'), school:v('p_school'), subject:v('p_subject'), exp:v('p_exp') };
+      return { city:v('p_city'), spec:v('p_spec'), exp:v('p_exp'), subject:v('p_subject') };
+    }
+
+    function validateProfile(r,p){
+      const req = (keys)=> keys.find(k=>!p[k]);
+      if(r==='student'){ const miss=req(['university','major','course']); if(miss) return 'Заполните: ВУЗ, направление и курс'; }
+      if(r==='teacher'){ const miss=req(['city','school','subject']); if(miss) return 'Заполните: город, школа, предмет'; }
+      if(r==='slp'){ const miss=req(['city','spec']); if(miss) return 'Заполните: город и специализацию'; }
+      return '';
     }
   }
-  canvas.addEventListener('mousemove', (e)=>{
-    const rect = canvas.getBoundingClientRect();
-    const x = (e.clientX - rect.left) * (canvas.width / rect.width);
-    const y = (e.clientY - rect.top) * (canvas.height / rect.height);
-    dot(x,y);
-    if(last){
-      ctx.strokeStyle = 'rgba(255,255,255,.18)';
-      ctx.lineWidth = 2;
-      ctx.beginPath(); ctx.moveTo(last.x,last.y); ctx.lineTo(x,y); ctx.stroke();
-    }
-    last = {x,y};
-  });
-  canvas.addEventListener('mouseleave', ()=> last=null);
+
+  /* ---------- Утилиты ---------- */
+  function showAuthErr(msg){ const el=document.getElementById('authErr'); if(!el) return; el.style.display='block'; el.textContent=msg; }
+  function toggleEye(id){ const el=document.getElementById(id); if(!el) return; el.type = el.type==='password' ? 'text' : 'password'; }
+
+  /* ---------- Мел (холст) ---------- */
+  function initChalk(){
+    const canvas = document.getElementById('chalk'); if(!canvas) return;
+    const ctx = canvas.getContext('2d'); let last = null;
+    function dot(x,y){ ctx.fillStyle='rgba(255,255,255,.7)'; for(let i=0;i<6;i++){ const ox=(Math.random()-.5)*3; const oy=(Math.random()-.5)*3; ctx.fillRect(x+ox,y+oy,1,1);} }
+    canvas.addEventListener('mousemove', (e)=>{ const r=canvas.getBoundingClientRect(); const x=(e.clientX-r.left)*(canvas.width/r.width); const y=(e.clientY-r.top)*(canvas.height/r.height); dot(x,y); if(last){ ctx.strokeStyle='rgba(255,255,255,.18)'; ctx.lineWidth=2; ctx.beginPath(); ctx.moveTo(last.x,last.y); ctx.lineTo(x,y); ctx.stroke(); } last={x,y}; });
+    canvas.addEventListener('mouseleave', ()=> last=null);
+  }
+
+  /* ---------- Общий рендер ---------- */
+  function renderAuth(){ renderHeaderUser(); renderHeroRight(); }
+  renderAuth();
 
   // Keyboard focus outline visible for accessibility
   document.addEventListener('keydown', (e)=>{ if(e.key === 'Tab'){ document.body.classList.add('kbd'); }});

--- a/index.html
+++ b/index.html
@@ -325,7 +325,6 @@ body.theme-light .btn.secondary{
 }
 .theme-light .profile-field{ background:#fff; border-color:#E6E8EB }
 .profile-actions{display:flex; gap:8px; margin-top:10px}
-
 </style>
 
 </head>


### PR DESCRIPTION
## Summary
- add styles for stepper, OTP inputs, role chips, and profile form
- implement multi-step auth flow with login/registration, email verification, and profile completion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf3b57e90832aa15cd7bd3e9fc1f7